### PR TITLE
Replace default db url = localhost with 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ cd ../client
 # Install dependencies
 $ npm install
 
-# Use the command below for Android devices
+# Use the command below for browser or Android devices
 $ npm run dev
 
 # To see the incomplete storybook components

--- a/server/config.js
+++ b/server/config.js
@@ -1,8 +1,8 @@
 module.exports = {
   port: process.env.PORT || 8080,
   db: {
-    prod: process.env.DATABASE_URL || 'mongodb://localhost/stackoverflow-clone',
-    test: 'mongodb://localhost/stackoverflow-test',
+    prod: process.env.DATABASE_URL || 'mongodb://127.0.0.1/stackoverflow-clone',
+    test: 'mongodb://127.0.0.1/stackoverflow-test',
     options: {
       useNewUrlParser: true,
       useUnifiedTopology: true,


### PR DESCRIPTION
Hi! Thank you for making this amazing thing🤩 
While starting the server with the default db url I kept getting `Error: connect ECONNREFUSED ::1:27017`.
Turns out newer versions of node can experience this when 'localhost' is used as db url. Replaced it with 127.0.0.1 and that seems to work fine. Did not confirm with older versions but I think they should be good with this url as well.